### PR TITLE
Add `Device::delete` method with related tests and documentation

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -40,13 +40,14 @@ export default defineConfig({
                     {text: 'Update Information', link: '/server/update-information'},
                 ]
             },
-{
+            {
                 text: 'Devices',
                 items: [
                     {text: 'Get All Devices', link: '/devices/get-all'},
                     {text: 'Get User Devices', link: '/devices/get-for-user'},
                     {text: 'Create Device', link: '/devices/create'},
                     {text: 'Update Device', link: '/devices/update'},
+                    {text: 'Delete Device', link: '/devices/delete'},
                 ]
             },
             {
@@ -71,6 +72,7 @@ export default defineConfig({
                     {text: 'Volume Unit', link: '/reference/enums/volume-unit'},
                     {text: 'Device Status', link: '/reference/enums/device-status'},
                     {text: 'Device Category', link: '/reference/enums/device-category'},
+                    {text: 'Status', link: '/reference/enums/status'},
                 ]
             },
         ],

--- a/docs/devices/delete.md
+++ b/docs/devices/delete.md
@@ -1,0 +1,35 @@
+# Delete Device
+
+Delete an existing device from your Traccar server.
+
+> [!WARNING]
+> Deleting a device is irreversible. Ensure you target the correct device ID.
+
+## Usage
+
+```php
+use TrackTelemetry\Traccar\Facades\Device;
+use TrackTelemetry\Traccar\Enums\Status;
+
+$deviceId = 6;
+
+$status = Device::delete(id: $deviceId); // returns TrackTelemetry\Traccar\Enums\Status
+
+if ($status === Status::SUCCESS) {
+    // Successfully deleted
+}
+```
+
+## Results
+
+The response is a `TrackTelemetry\Traccar\Enums\Status` enum.
+
+```php
+$status->value; // 'success' or 'failure'
+$status->name;  // 'SUCCESS' or 'FAILURE'
+$status->label(); // 'Success' or 'Failure'
+```
+
+## Important Links
+- Traccar Delete a Device: https://www.traccar.org/api-reference/#tag/Devices/paths/~1devices~1%7Bid%7D/delete
+- [Status enum reference](./../reference/enums/status)

--- a/docs/reference/enums/status.md
+++ b/docs/reference/enums/status.md
@@ -1,0 +1,31 @@
+# Status Enum Reference
+
+The `TrackTelemetry\Traccar\Enums\Status` enum represents a boolean-like operation result for actions such as deleting a device.
+
+## Example
+
+```php
+use TrackTelemetry\Traccar\Enums\Status;
+
+$status = Status::SUCCESS;
+$status->value; // 'success'
+$status->name; // 'SUCCESS'
+$status->label(); // 'Success'
+```
+
+## Enum Cases
+
+| Case      | Value      | Description                         |
+|-----------|------------|-------------------------------------|
+| `SUCCESS` | `'success'`| Operation completed successfully.   |
+| `FAILURE` | `'failure'`| Operation failed.                   |
+
+## Methods
+
+### `public static function default(): self`
+
+Returns the default status (`FAILURE`).
+
+### `public function label(): string`
+
+Returns a human-readable label for the status (e.g., `"Success"`).

--- a/src/Endpoints/Device.php
+++ b/src/Endpoints/Device.php
@@ -6,8 +6,10 @@ namespace TrackTelemetry\Traccar\Endpoints;
 
 use Illuminate\Support\Collection;
 use TrackTelemetry\Traccar\Traccar;
+use TrackTelemetry\Traccar\Enums\Status;
 use TrackTelemetry\Traccar\Dto\DeviceData;
 use TrackTelemetry\Traccar\Requests\CreateDevice;
+use TrackTelemetry\Traccar\Requests\DeleteDevice;
 use TrackTelemetry\Traccar\Requests\UpdateDevice;
 use TrackTelemetry\Traccar\Requests\GetAllDevices;
 use TrackTelemetry\Traccar\Requests\GetForUserDevices;
@@ -65,6 +67,18 @@ class Device extends Traccar
     public function update(DeviceData $data): DeviceData
     {
         $response = $this->connector->send(request: new UpdateDevice(data: $data));
+
+        return $response->dtoOrFail();
+    }
+
+    /**
+     * Delete a device by ID.
+     *
+     * @throws \Saloon\Exceptions\SaloonException
+     */
+    public function delete(int $id): Status
+    {
+        $response = $this->connector->send(request: new DeleteDevice(id: $id));
 
         return $response->dtoOrFail();
     }

--- a/src/Enums/Status.php
+++ b/src/Enums/Status.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Enums;
+
+enum Status: string
+{
+    case SUCCESS = 'success';
+    case FAILURE = 'failure';
+
+    public static function default(): self
+    {
+        return self::FAILURE;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SUCCESS => 'Success',
+            self::FAILURE => 'Failure',
+        };
+    }
+}

--- a/src/Requests/DeleteDevice.php
+++ b/src/Requests/DeleteDevice.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use TrackTelemetry\Traccar\Enums\Status;
+
+class DeleteDevice extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function __construct(public int $id)
+    {
+    }
+
+    /**
+     * Resolves and returns the API endpoint for deleting a device.
+     */
+    public function resolveEndpoint(): string
+    {
+        return "/devices/{$this->id}";
+    }
+
+    /**
+     * Return an enum status from the response.
+     */
+    public function createDtoFromResponse(Response $response): Status
+    {
+        return Status::SUCCESS;
+    }
+}

--- a/tests/Feature/DeviceTest.php
+++ b/tests/Feature/DeviceTest.php
@@ -6,11 +6,13 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use TrackTelemetry\Traccar\Enums\Status;
 use TrackTelemetry\Traccar\Dto\DeviceData;
 use TrackTelemetry\Traccar\Facades\Device;
 use TrackTelemetry\Traccar\Enums\DeviceStatus;
 use TrackTelemetry\Traccar\Enums\DeviceCategory;
 use TrackTelemetry\Traccar\Requests\CreateDevice;
+use TrackTelemetry\Traccar\Requests\DeleteDevice;
 use TrackTelemetry\Traccar\Requests\UpdateDevice;
 use TrackTelemetry\Traccar\Requests\GetAllDevices;
 use TrackTelemetry\Traccar\Dto\DeviceAttributesData;
@@ -229,4 +231,16 @@ it(description: 'can update a device', closure: function () {
         ->toBeInstanceOf(class: DeviceData::class)
         ->and(value: $response->name)->toEqual(expected: 'Truck 1 - Updated')
         ->and(value: $response->attributes->speedLimit)->toBeFloat();
+});
+
+it(description: 'can delete a device', closure: function () {
+    MockClient::global(mockData: [
+        DeleteDevice::class => MockResponse::make(body: '', status: 204),
+    ]);
+
+    $status = Device::delete(id: 6);
+
+    expect(value: $status)
+        ->toBeInstanceOf(class: Status::class)
+        ->and(value: $status)->toEqual(expected: Status::SUCCESS);
 });


### PR DESCRIPTION
- Introduce `Device::delete` method to delete existing devices in Traccar with typed request and response handling.
- Add `DeleteDevice` request class to handle API interactions.
- Create `Status` enum to standardize operation results (`SUCCESS`/`FAILURE`) with relevant methods.
- Update VitePress navigation and add `devices/delete.md` with usage examples, warnings, and API reference.
- Add feature test to validate the functionality of `Device::delete`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete a device by ID with explicit success/failure status.
  * Added a unified Status enum for operation outcomes.

* **Documentation**
  * New “Delete Device” guide with usage example and behavior notes.
  * New “Status” reference documenting values, default and labels.
  * Sidebar updated to include “Delete Device” and “Status” pages.

* **Tests**
  * Added a test verifying device deletion returns success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->