### PR TITLE
Add support for retrieving Traccar events by ID

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -47,6 +47,13 @@ export default defineConfig({
                     {text: 'Reverse Geocode', link: '/server/geocode'},
                 ]
             },
+            {
+                text: 'Events',
+                collapsed: true,
+                items: [
+                    {text: 'Get Information', link: '/events/get-information'},
+                ]
+            },
 {
                 text: 'Devices',
                 collapsed: true,
@@ -70,6 +77,7 @@ export default defineConfig({
                     {text: 'Device Data', link: '/reference/dto/device-data'},
                     {text: 'Device Attribute Data', link: '/reference/dto/device-attributes-data'},
                     {text: 'Device Share Data', link: '/reference/dto/device-share-data'},
+                    {text: 'Event Data', link: '/reference/dto/event-data'},
                 ]
             },
             {

--- a/docs/events/get-information.md
+++ b/docs/events/get-information.md
@@ -1,0 +1,32 @@
+# Retrieve Event Information
+
+Fetch a specific event by its ID from your Traccar server.
+
+## Request
+
+Use the `TrackTelemetry\Traccar\Facades\Event::get(int $id)` method to retrieve a single event.
+
+```php
+use TrackTelemetry\Traccar\Facades\Event;
+
+$event = Event::get(1234); // TrackTelemetry\Traccar\Dto\EventData
+```
+
+## Result
+
+The response is an instance of `TrackTelemetry\Traccar\Dto\EventData`.
+
+```php
+$id         = $event->id; / 1234
+$type       = $event->type; // "geofenceEnter", "ignitionOn", etc.
+$occurredAt = $event->eventTime->toIso8601String();
+$deviceId   = $event->deviceId; // 42
+$positionId = $event->positionId; // maybe null depending on an event type
+$geofenceId = $event->geofenceId; // maybe null
+$attrs      = $event->attributes; // array<string, mixed>
+```
+
+
+## Important Links
+- [Traccar: Get Event by ID](https://www.traccar.org/api-reference/#tag/Events/paths/~1events~1%7Bid%7D/get)
+- [EventData DTO reference](./../reference/dto/event-data)

--- a/docs/reference/dto/event-data.md
+++ b/docs/reference/dto/event-data.md
@@ -1,0 +1,65 @@
+# Event Data DTO Reference
+
+The `TrackTelemetry\\Traccar\\Dto\\EventData` represents a Traccar event entity. Events describe state changes or notable conditions detected by the server (e.g., geofence enter/exit, ignition on/off, overspeed, etc.).
+
+```php
+use TrackTelemetry\\Traccar\\Facades\\Event;
+
+$event = Event::get(1234); // EventData
+```
+
+## `id` → `integer`
+Unique event identifier in Traccar.
+
+```php
+$event->id; // 1234
+```
+
+## `type` → `string`
+Traccar event type string (e.g., `"geofenceEnter"`, `"ignitionOn"`, `"deviceOnline"`).
+
+```php
+$event->type; // "geofenceEnter"
+```
+
+## `eventTime` → `CarbonImmutable`
+Time the event occurred, parsed from ISO 8601.
+
+```php
+$event->eventTime->toIso8601String(); // "2019-08-24T14:15:22Z"
+```
+
+## `deviceId` → `integer`
+The device associated with this event.
+
+```php
+$event->deviceId; // 42
+```
+
+## `positionId` → `integer|null`
+Associated position record ID, if applicable for the event type.
+
+```php
+$event->positionId; // 98765 or null
+```
+
+## `geofenceId` → `integer|null`
+Associated geofence ID for geofence-related events.
+
+```php
+$event->geofenceId; // 3 or null
+```
+
+## `maintenanceId` → `integer|null`
+Associated maintenance record ID, if applicable.
+
+```php
+$event->maintenanceId; // 10 or null
+```
+
+## `attributes` → `array<string, mixed>`
+Event-specific attributes payload returned by Traccar.
+
+```php
+$event->attributes; // [ 'alarm' => 'powerCut', 'speed' => 32.1, ... ]
+```

--- a/src/Dto/EventData.php
+++ b/src/Dto/EventData.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Dto;
+
+use Throwable;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Log;
+
+class EventData
+{
+    public function __construct(
+        public int $id,
+        public string $type,
+        public CarbonImmutable $eventTime,
+        public int $deviceId,
+        public ?int $positionId = null,
+        public ?int $geofenceId = null,
+        public ?int $maintenanceId = null,
+        /** @var array<string, mixed> */
+        public array $attributes = [],
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        $rawEventTime = $data['eventTime'] ?? null;
+        $eventTime = CarbonImmutable::now();
+
+        if (is_string($rawEventTime) && $rawEventTime !== '') {
+            try {
+                $eventTime = CarbonImmutable::parse($rawEventTime);
+            } catch (Throwable $e) {
+                Log::info('Failed to parse Event eventTime: '.$e->getMessage());
+            }
+        }
+
+        return new self(
+            id: (int) ($data['id'] ?? 0),
+            type: (string) ($data['type'] ?? ''),
+            eventTime: $eventTime,
+            deviceId: (int) ($data['deviceId'] ?? 0),
+            positionId: array_key_exists('positionId', $data) ? (is_null($data['positionId']) ? null : (int) $data['positionId']) : null,
+            geofenceId: array_key_exists('geofenceId', $data) ? (is_null($data['geofenceId']) ? null : (int) $data['geofenceId']) : null,
+            maintenanceId: array_key_exists('maintenanceId', $data) ? (is_null($data['maintenanceId']) ? null : (int) $data['maintenanceId']) : null,
+            attributes: is_array($data['attributes'] ?? null) ? $data['attributes'] : [],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id'            => $this->id,
+            'type'          => $this->type,
+            'eventTime'     => $this->eventTime->toIso8601String(),
+            'deviceId'      => $this->deviceId,
+            'positionId'    => $this->positionId,
+            'geofenceId'    => $this->geofenceId,
+            'maintenanceId' => $this->maintenanceId,
+            'attributes'    => $this->attributes,
+        ];
+    }
+}

--- a/src/Endpoints/Event.php
+++ b/src/Endpoints/Event.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Endpoints;
+
+use TrackTelemetry\Traccar\Traccar;
+use TrackTelemetry\Traccar\Dto\EventData;
+use TrackTelemetry\Traccar\Requests\GetEvent;
+
+class Event extends Traccar
+{
+    /**
+     * Retrieve an event by ID.
+     *
+     * @throws \Saloon\Exceptions\SaloonException
+     */
+    public function get(int $id): EventData
+    {
+        $response = $this->connector->send(request: new GetEvent(id: $id));
+
+        return $response->dtoOrFail();
+    }
+}

--- a/src/Facades/Event.php
+++ b/src/Facades/Event.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @see \TrackTelemetry\Traccar\Endpoints\Event
+ */
+class Event extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return \TrackTelemetry\Traccar\Endpoints\Event::class;
+    }
+}

--- a/src/Requests/GetEvent.php
+++ b/src/Requests/GetEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Requests;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use TrackTelemetry\Traccar\Dto\EventData;
+
+class GetEvent extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(public int $id)
+    {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/events/{$this->id}";
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): EventData
+    {
+        return EventData::fromArray($response->json());
+    }
+}

--- a/tests/Feature/EventTest.php
+++ b/tests/Feature/EventTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\CarbonImmutable;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use TrackTelemetry\Traccar\Dto\EventData;
+use TrackTelemetry\Traccar\Facades\Event;
+use TrackTelemetry\Traccar\Requests\GetEvent;
+
+it(description: 'can retrieve an event by id', closure: function () {
+    $payload = [
+        'id'            => 1234,
+        'type'          => 'geofenceEnter',
+        'eventTime'     => '2019-08-24T14:15:22Z',
+        'deviceId'      => 42,
+        'positionId'    => 98765,
+        'geofenceId'    => 3,
+        'maintenanceId' => null,
+        'attributes'    => [
+            'alarm' => 'powerCut',
+            'speed' => 32.1,
+        ],
+    ];
+
+    MockClient::global(mockData: [
+        GetEvent::class => MockResponse::make($payload),
+    ]);
+
+    $event = Event::get(id: 1234);
+
+    expect(value: $event)
+        ->toBeInstanceOf(class: EventData::class)
+        ->and(value: $event->id)->toEqual(expected: 1234)
+        ->and(value: $event->type)->toEqual(expected: 'geofenceEnter')
+        ->and(value: $event->eventTime)->toBeInstanceOf(class: CarbonImmutable::class)
+        ->and(value: $event->eventTime->toIso8601String())->toEqual(expected: '2019-08-24T14:15:22+00:00')
+        ->and(value: $event->deviceId)->toEqual(expected: 42)
+        ->and(value: $event->positionId)->toEqual(expected: 98765)
+        ->and(value: $event->geofenceId)->toEqual(expected: 3)
+        ->and(value: $event->maintenanceId)->toBeNull()
+        ->and(value: $event->attributes)->toBeArray()
+        ->and(value: $event->attributes['alarm'])->toEqual(expected: 'powerCut');
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -194,3 +194,11 @@ Route::prefix('/devices')->group(function () {
         dump($share->toArray());
     });
 });
+
+Route::prefix('/events')->group(function () {
+    Route::get('/{id}', function (int $id) {
+        $event = \TrackTelemetry\Traccar\Facades\Event::get(id: $id);
+
+        dump($event->toArray());
+    });
+});


### PR DESCRIPTION
Introduces EventData DTO, Event endpoint, facade, and request for fetching event details from Traccar by ID. Adds documentation and a feature test for event retrieval. Updates documentation navigation and workbench routes to demonstrate event fetching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event retrieval functionality enabling users to fetch specific event information by ID from the Traccar server.

* **Documentation**
  * Added comprehensive documentation for event data retrieval and the Event Data structure with field descriptions and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->