### PR TITLE
Add support for retrieving all users

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
                 collapsed: true,
                 items: [
                     {text: 'Get Information', link: '/users/get-information'},
+                    {text: 'Get All', link: '/users/get-all'},
                 ]
             },
             {

--- a/docs/users/get-all.md
+++ b/docs/users/get-all.md
@@ -1,0 +1,25 @@
+# Get All Users
+
+Fetch all users from your Traccar server.
+
+> [!WARNING]
+> Can only be used by admin or manager users.
+
+## Request
+
+Use the `TrackTelemetry\Traccar\Facades\User::all()` method to retrieve all users.
+
+```php
+use TrackTelemetry\Traccar\Facades\User;
+
+$users = User::all(); // array of TrackTelemetry\Traccar\Dto\UserData
+```
+
+## Result
+
+Returns an array of `TrackTelemetry\Traccar\Dto\UserData` instances.
+
+```php
+$first = $users[0];
+$first->name; // string
+```

--- a/src/Endpoints/User.php
+++ b/src/Endpoints/User.php
@@ -7,6 +7,7 @@ namespace TrackTelemetry\Traccar\Endpoints;
 use TrackTelemetry\Traccar\Traccar;
 use TrackTelemetry\Traccar\Dto\UserData;
 use TrackTelemetry\Traccar\Requests\GetUser;
+use TrackTelemetry\Traccar\Requests\GetAllUsers;
 
 class User extends Traccar
 {
@@ -18,6 +19,20 @@ class User extends Traccar
     public function get(int $id): UserData
     {
         $response = $this->connector->send(request: new GetUser(id: $id));
+
+        return $response->dtoOrFail();
+    }
+
+    /**
+     * Get all users
+     *
+     * @return array<int, UserData>
+     *
+     * @throws \Saloon\Exceptions\SaloonException
+     */
+    public function all(): array
+    {
+        $response = $this->connector->send(request: new GetAllUsers());
 
         return $response->dtoOrFail();
     }

--- a/src/Requests/GetAllUsers.php
+++ b/src/Requests/GetAllUsers.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Requests;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use TrackTelemetry\Traccar\Dto\UserData;
+
+class GetAllUsers extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function resolveEndpoint(): string
+    {
+        return '/users';
+    }
+
+    /**
+     * @return array<int, UserData>
+     *
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        $json = $response->json();
+
+        if (! is_array($json)) {
+            return [];
+        }
+
+        return array_map(fn ($u) => UserData::fromArray((array) $u), $json);
+    }
+}

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -61,6 +61,68 @@ it(description: 'throws JsonException on invalid JSON response', closure: functi
     expect(value: fn () => User::get(1))->toThrow(exception: JsonException::class);
 });
 
+it(description: 'can retrieve all users', closure: function () {
+    $payload = [
+        [
+            'id'               => 1,
+            'name'             => 'Alice',
+            'email'            => 'alice@example.com',
+            'phone'            => null,
+            'readonly'         => false,
+            'administrator'    => false,
+            'map'              => 'osm',
+            'latitude'         => 0,
+            'longitude'        => 0,
+            'zoom'             => 10,
+            'password'         => null,
+            'coordinateFormat' => 'dd',
+            'disabled'         => false,
+            'expirationTime'   => null,
+            'deviceLimit'      => 0,
+            'userLimit'        => 0,
+            'deviceReadonly'   => false,
+            'limitCommands'    => false,
+            'fixedEmail'       => false,
+            'poiLayer'         => null,
+            'attributes'       => [],
+        ],
+        [
+            'id'               => 2,
+            'name'             => 'Bob',
+            'email'            => 'bob@example.com',
+            'phone'            => null,
+            'readonly'         => false,
+            'administrator'    => false,
+            'map'              => 'osm',
+            'latitude'         => 0,
+            'longitude'        => 0,
+            'zoom'             => 10,
+            'password'         => null,
+            'coordinateFormat' => 'dd',
+            'disabled'         => false,
+            'expirationTime'   => null,
+            'deviceLimit'      => 0,
+            'userLimit'        => 0,
+            'deviceReadonly'   => false,
+            'limitCommands'    => false,
+            'fixedEmail'       => false,
+            'poiLayer'         => null,
+            'attributes'       => [],
+        ],
+    ];
+
+    MockClient::global(mockData: [
+        \TrackTelemetry\Traccar\Requests\GetAllUsers::class => MockResponse::make($payload),
+    ]);
+
+    $users = User::all();
+
+    expect($users)
+        ->toBeArray()
+        ->and(count($users))->toBe(2)
+        ->and($users[0])->toBeInstanceOf(UserData::class);
+});
+
 it(description: 'throws NotFoundException when user is missing', closure: function () {
     MockClient::global(mockData: [
         GetUser::class => MockResponse::make([], 200),

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -204,6 +204,14 @@ Route::prefix('/events')->group(function () {
 });
 
 Route::prefix('/users')->group(function () {
+
+
+    Route::get('/all', function () {
+        $users = \TrackTelemetry\Traccar\Facades\User::all();
+
+        dump($users);
+    });
+
     Route::get('/{id}', function (int $id) {
         $user = \TrackTelemetry\Traccar\Facades\User::get(id: $id);
 


### PR DESCRIPTION
Implemented the User::all() method and GetAllUsers request to fetch all users from the Traccar server. Added documentation, tests, and a sample route in the workbench for this new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to retrieve all users in a single operation (accessible to admin and manager users only)

* **Documentation**
  * Added comprehensive guide with code examples for the new Get All Users functionality

* **Tests**
  * Added test coverage for the Get All Users feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->