### PR TITLE
Add server statistics endpoint and DTO

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -45,6 +45,7 @@ export default defineConfig({
                     {text: 'Upload File', link: '/server/upload-file'},
                     {text: 'Timezones', link: '/server/timezones'},
                     {text: 'Reverse Geocode', link: '/server/geocode'},
+                    {text: 'Statistics', link: '/server/statistics'},
                 ]
             },
             {
@@ -91,6 +92,7 @@ export default defineConfig({
                     {text: 'Event Data', link: '/reference/dto/event-data'},
                     {text: 'User Data', link: '/reference/dto/user-data'},
                     {text: 'User Attributes Data', link: '/reference/dto/user-attributes-data'},
+                    {text: 'Server Statistics Data', link: '/reference/dto/server-statistics-data'},
                 ]
             },
             {

--- a/docs/reference/dto/server-statistics-data.md
+++ b/docs/reference/dto/server-statistics-data.md
@@ -1,0 +1,25 @@
+# Server Statistics Data DTO
+
+Represents one statistics record returned by the Traccar `/statistics` endpoint.
+
+```php
+$first = Server::statistics($from, $to);
+```
+
+## `captureTime` → `CarbonImmutable`
+ISO 8601 timestamp when the snapshot was captured.
+
+## `activeUsers` → `integer`
+Number of active users.
+
+## `activeDevices` → `integer`
+Number of active devices.
+
+## `requests` → `integer`
+Number of HTTP requests processed.
+
+## `messagesReceived` → `integer`
+Number of messages received from devices.
+
+## `messagesStored` → `integer`
+Number of messages stored after processing.

--- a/docs/server/statistics.md
+++ b/docs/server/statistics.md
@@ -1,0 +1,33 @@
+# Statistics
+
+Fetch aggregated server statistics for a time range.
+
+## Request
+
+```php
+use Carbon\CarbonImmutable;
+use TrackTelemetry\Traccar\Facades\Server;
+
+$from = CarbonImmutable::parse('01 June 2025');
+$to   = CarbonImmutable::parse('25 Nov 2025');
+
+$stats = Server::statistics(from: $from, to: $to); // Illuminate\Support\Collection of ServerStatisticsData
+```
+
+## Results
+
+The response is a Laravel Collection of `ServerStatisticsData` items, for example:
+
+```php
+$first = $stats->first();
+$first->captureTime->toIso8601String(); // "2019-08-24T14:15:22+00:00"
+$first->activeUsers; // 2
+$first->activeDevices; // 5
+$first->requests;  // 120
+$first->messagesReceived; // 450
+$first->messagesStored; // 440
+```
+
+## Important Links
+- [Traccar Statistics](https://www.traccar.org/api-reference/#tag/Statistics/paths/~1statistics/get)
+- [ServerStatisticsData DTO reference](./../reference/dto/server-statistics-data)

--- a/docs/users/create.md
+++ b/docs/users/create.md
@@ -60,6 +60,6 @@ $created->attributes->toArray();
 ```
 
 ## Important Links
-- Traccar Create User: https://www.traccar.org/api-reference/#tag/Users/paths/~1users/post
+- [Traccar Create User](https://www.traccar.org/api-reference/#tag/Users/paths/~1users/post)
 - [UserData DTO reference](./../reference/dto/user-data)
 - [UserAttributesData DTO reference](./../reference/dto/user-attributes-data)

--- a/docs/users/delete.md
+++ b/docs/users/delete.md
@@ -32,5 +32,5 @@ $result->status->label(); // 'Success' or 'Failure'
 ```
 
 ## Important Links
-- Traccar Delete User: https://www.traccar.org/api-reference/#tag/Users/paths/~1users~1%7Bid%7D/delete
+- [Traccar Delete User](https://www.traccar.org/api-reference/#tag/Users/paths/~1users~1%7Bid%7D/delete)
 - [Status enum reference](./../reference/enums/status)

--- a/docs/users/get-all.md
+++ b/docs/users/get-all.md
@@ -23,3 +23,7 @@ Returns an array of `TrackTelemetry\Traccar\Dto\UserData` instances.
 $first = $users[0];
 $first->name; // string
 ```
+
+## Important Links
+- [Traccar: Get User by ID](https://www.traccar.org/api-reference/#tag/Users/paths/~1users/get)
+- [UserData DTO reference](./../reference/dto/user-data)

--- a/docs/users/update.md
+++ b/docs/users/update.md
@@ -3,7 +3,7 @@
 Update an existing user on your Traccar server.
 
 > [!IMPORTANT]
-> Recommended workflow: fetch the user DTO first, modify only the fields you need, then send the updated DTO. This avoids accidental resets.
+> **Recommended workflow**: fetch the user DTO first, modify only the fields you need, then send the updated DTO. This avoids accidental resets.
 
 ## Usage
 
@@ -28,11 +28,11 @@ $updated = User::update($user); // returns TrackTelemetry\Traccar\Dto\UserData
 ## Results
 
 ```php
-$updated->id;         // 42
-$updated->name;       // "Jane Doe (Updated)"
+$updated->id; // 42
+$updated->name; // "Jane Doe (Updated)"
 $updated->map->value; // e.g., "osm"
 ```
 
 ## Important Links
-- Traccar Update User: https://www.traccar.org/api-reference/#tag/Users/paths/~1users~1%7Bid%7D/put
+- [Traccar Update User](https://www.traccar.org/api-reference/#tag/Users/paths/~1users~1%7Bid%7D/put)
 - [UserData DTO reference](./../reference/dto/user-data)

--- a/src/Dto/ServerStatisticsData.php
+++ b/src/Dto/ServerStatisticsData.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Dto;
+
+use Throwable;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Log;
+
+class ServerStatisticsData
+{
+    public function __construct(
+        public CarbonImmutable $captureTime,
+        public int $activeUsers,
+        public int $activeDevices,
+        public int $requests,
+        public int $messagesReceived,
+        public int $messagesStored,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        $time = CarbonImmutable::now();
+        try {
+            $raw = (string) ($data['captureTime'] ?? '');
+            if ($raw !== '') {
+                $time = CarbonImmutable::parse($raw);
+            }
+        } catch (Throwable $e) {
+            Log::info('Failed to parse statistics captureTime: '.$e->getMessage());
+        }
+
+        return new self(
+            captureTime: $time,
+            activeUsers: (int) ($data['activeUsers'] ?? 0),
+            activeDevices: (int) ($data['activeDevices'] ?? 0),
+            requests: (int) ($data['requests'] ?? 0),
+            messagesReceived: (int) ($data['messagesReceived'] ?? 0),
+            messagesStored: (int) ($data['messagesStored'] ?? 0),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'captureTime'      => $this->captureTime->toIso8601String(),
+            'activeUsers'      => $this->activeUsers,
+            'activeDevices'    => $this->activeDevices,
+            'requests'         => $this->requests,
+            'messagesReceived' => $this->messagesReceived,
+            'messagesStored'   => $this->messagesStored,
+        ];
+    }
+}

--- a/src/Endpoints/Server.php
+++ b/src/Endpoints/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrackTelemetry\Traccar\Endpoints;
 
+use Carbon\CarbonInterface;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use TrackTelemetry\Traccar\Traccar;
@@ -16,8 +17,10 @@ use TrackTelemetry\Traccar\Requests\RebootServer;
 use TrackTelemetry\Traccar\Requests\GetServerCache;
 use TrackTelemetry\Traccar\Requests\ReverseGeocode;
 use Saloon\Exceptions\Request\FatalRequestException;
+use TrackTelemetry\Traccar\Dto\ServerStatisticsData;
 use TrackTelemetry\Traccar\Requests\UploadServerFile;
 use TrackTelemetry\Traccar\Requests\GetServerTimezones;
+use TrackTelemetry\Traccar\Requests\GetServerStatistics;
 use TrackTelemetry\Traccar\Requests\RunGarbageCollector;
 use TrackTelemetry\Traccar\Requests\GetServerInformation;
 use TrackTelemetry\Traccar\Requests\UpdateServerInformation;
@@ -171,6 +174,19 @@ class Server extends Traccar
     public function geocode(float $latitude, float $longitude): string
     {
         $response = $this->connector->send(request: new ReverseGeocode(latitude: $latitude, longitude: $longitude));
+
+        return $response->dtoOrFail();
+    }
+    /**
+     * Get aggregated server statistics between two timestamps.
+     *
+     * @throws \Saloon\Exceptions\SaloonException
+     */
+    public function statistics(CarbonInterface $from, CarbonInterface $to): ServerStatisticsData
+    {
+        $response = $this->connector->send(
+            request: new GetServerStatistics(from: $from, to: $to)
+        );
 
         return $response->dtoOrFail();
     }

--- a/src/Requests/GetAllUsers.php
+++ b/src/Requests/GetAllUsers.php
@@ -26,12 +26,9 @@ class GetAllUsers extends Request
      */
     public function createDtoFromResponse(Response $response): array
     {
-        $json = $response->json();
-
-        if (! is_array($json)) {
-            return [];
-        }
-
-        return array_map(fn ($u) => UserData::fromArray((array) $u), $json);
+        return array_map(
+            callback: fn ($u) => UserData::fromArray(data: (array) $u),
+            array: $response->json()
+        );
     }
 }

--- a/src/Requests/GetServerStatistics.php
+++ b/src/Requests/GetServerStatistics.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrackTelemetry\Traccar\Requests;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Arr;
+use TrackTelemetry\Traccar\Dto\ServerStatisticsData;
+use Saloon\Exceptions\Request\Statuses\NotFoundException;
+
+class GetServerStatistics extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected CarbonInterface $from,
+        protected CarbonInterface $to,
+    ) {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return '/statistics';
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function createDtoFromResponse(Response $response): ServerStatisticsData
+    {
+        $json = $response->json();
+
+        if ($json === []) {
+            throw new NotFoundException(
+                response: $response,
+                message: 'Statistics were not found. Check the date range and try again.'
+            );
+        }
+
+        return ServerStatisticsData::fromArray(
+            data: Arr::first(array: $response->json())
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultQuery(): array
+    {
+        return [
+            'from' => $this->from->toIso8601String(),
+            'to'   => $this->to->toIso8601String(),
+        ];
+    }
+}

--- a/tests/Feature/ServerTest.php
+++ b/tests/Feature/ServerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
 use Saloon\Http\PendingRequest;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
@@ -15,8 +16,10 @@ use TrackTelemetry\Traccar\Requests\RebootServer;
 use TrackTelemetry\Traccar\Requests\GetServerCache;
 use TrackTelemetry\Traccar\Requests\ReverseGeocode;
 use Saloon\Exceptions\Request\FatalRequestException;
+use TrackTelemetry\Traccar\Dto\ServerStatisticsData;
 use TrackTelemetry\Traccar\Requests\UploadServerFile;
 use TrackTelemetry\Traccar\Requests\GetServerTimezones;
+use TrackTelemetry\Traccar\Requests\GetServerStatistics;
 use TrackTelemetry\Traccar\Requests\RunGarbageCollector;
 use TrackTelemetry\Traccar\Requests\GetServerInformation;
 use TrackTelemetry\Traccar\Requests\UpdateServerInformation;
@@ -174,4 +177,32 @@ it(description: 'can reverse geocode coordinates', closure: function () {
     expect(value: $address)
         ->toBeString()
         ->toEqual(expected: 'Nairobi, Kenya');
+});
+
+it(description: 'can fetch server statistics between dates', closure: function () {
+    $payload = [
+        [
+            'captureTime'      => '2019-08-24T14:15:22Z',
+            'activeUsers'      => 2,
+            'activeDevices'    => 5,
+            'requests'         => 120,
+            'messagesReceived' => 450,
+            'messagesStored'   => 440,
+        ],
+    ];
+
+    MockClient::global(mockData: [
+        GetServerStatistics::class => MockResponse::make($payload),
+    ]);
+
+    $from = CarbonImmutable::parse(time: '2019-08-24T00:00:00Z');
+    $to = CarbonImmutable::parse(time: '2019-08-25T00:00:00Z');
+
+    $stats = Server::statistics(from: $from, to: $to);
+
+    expect(value: $stats)
+        ->toBeInstanceOf(class: ServerStatisticsData::class)
+        ->and(value: $stats->captureTime)->toBeInstanceOf(class: CarbonImmutable::class)
+        ->and(value: $stats->activeUsers)->toEqual(expected: 2)
+        ->and(value: $stats->messagesStored)->toEqual(expected: 440);
 });

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -80,6 +80,16 @@ Route::prefix('/server')->group(function () {
 
         dump($address);
     });
+
+    Route::get('/statistics', function () {
+
+        $stats = \TrackTelemetry\Traccar\Facades\Server::statistics(
+            from: \Carbon\CarbonImmutable::parse(time: '01 Oct 2025'),
+            to: \Carbon\CarbonImmutable::parse(time: '31 Nov 2025')
+        );
+
+        dump($stats);
+    });
 });
 
 Route::prefix('/devices')->group(function () {


### PR DESCRIPTION
Introduces the ServerStatisticsData DTO, GetServerStatistics request, and Server::statistics() method to fetch aggregated server statistics for a given date range. Updates documentation and tests to cover the new statistics functionality, and adds a route in the workbench for manual testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server statistics API endpoint to retrieve aggregated server metrics over a specified time range.

* **Documentation**
  * Added documentation pages for server statistics and related data structures.
  * Enhanced documentation formatting with improved hyperlinks and code example presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->