### PR TITLE
Fix formatting of Packagist downloads badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/thingstelemetry/laravel-traccar.svg?style=flat-square)](https://packagist.org/packages/thingstelemetry/laravel-traccar)
 ![GitHub Actions Test Status](https://img.shields.io/github/actions/workflow/status/thingstelemetry/laravel-traccar/tests.yml?logo=github&label=Tests)
-+[![Total Downloads](https://img.shields.io/packagist/dt/thingstelemetry/laravel-traccar.svg?style=flat-square)](https://packagist.org/packages/thingstelemetry/laravel-traccar)
+[![Total Downloads](https://img.shields.io/packagist/dt/thingstelemetry/laravel-traccar.svg?style=flat-square)](https://packagist.org/packages/thingstelemetry/laravel-traccar)
 
 ![Traccar Screenshot](./docs/images/traccar-home-page.webp)
 


### PR DESCRIPTION
Removed an unnecessary '+' character before the Packagist downloads badge to correct the formatting in the README.md file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed formatting error in the Total Downloads badge display in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->