### PR TITLE
Add "Delete Position" functionality with documentation and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
                 "Server": "ThingsTelemetry\\Traccar\\Facades\\Server",
                 "Device": "ThingsTelemetry\\Traccar\\Facades\\Device",
                 "Event": "ThingsTelemetry\\Traccar\\Facades\\Event",
-                "User": "ThingsTelemetry\\Traccar\\Facades\\User"
+                "User": "ThingsTelemetry\\Traccar\\Facades\\User",
+                "Position": "ThingsTelemetry\\Traccar\\Facades\\Position"
             }
         }
     },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -81,6 +81,13 @@ export default defineConfig({
                 ]
             },
             {
+                text: 'Positions',
+                collapsed: true,
+                items: [
+                    {text: 'Delete Position', link: '/positions/delete'},
+                ]
+            },
+            {
                 text: 'DTO Reference',
                 collapsed: true,
                 items: [

--- a/docs/positions/delete.md
+++ b/docs/positions/delete.md
@@ -1,0 +1,36 @@
+# Delete Position
+
+Delete an existing position from your Traccar server.
+
+> [!WARNING]
+> Deleting a position is irreversible and can compromise data integrity. Ensure you target the correct position ID.
+
+## Usage
+
+```php
+use ThingsTelemetry\Traccar\Dto\StatusData;
+use ThingsTelemetry\Traccar\Facades\Position;
+use ThingsTelemetry\Traccar\Enums\Status;
+
+$positionId = 12345;
+
+$result = Position::delete(id: $positionId); // returns ThingsTelemetry\Traccar\Dto\StatusData
+
+if ($result->status === Status::SUCCESS) {
+    // Successfully deleted
+}
+```
+
+## Results
+
+The response is a `ThingsTelemetry\Traccar\Dto\StatusData` object containing a `ThingsTelemetry\Traccar\Enums\Status`.
+
+```php
+$result->status->value; // 'success' or 'failure'
+$result->status->name;  // 'SUCCESS' or 'FAILURE'
+$result->status->label(); // 'Success' or 'Failure'
+```
+
+## Important Links
+- [Traccar Delete a Position](https://www.traccar.org/api-reference/#tag/Positions/paths/~1positions~1%7Bid%7D/delete)
+- [Status enum reference](./../reference/enums/status)

--- a/src/Endpoints/Device.php
+++ b/src/Endpoints/Device.php
@@ -39,7 +39,7 @@ class Device extends Traccar
     }
 
     /**
-     * Get devices by id, unique id or user id
+     * Get devices by id, unique id, or user id
      * or returns a list of the user's devices
      *
      * @throws \Saloon\Exceptions\SaloonException

--- a/src/Endpoints/Position.php
+++ b/src/Endpoints/Position.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingsTelemetry\Traccar\Endpoints;
+
+use ThingsTelemetry\Traccar\Traccar;
+use ThingsTelemetry\Traccar\Dto\StatusData;
+use ThingsTelemetry\Traccar\Requests\DeletePosition;
+
+class Position extends Traccar
+{
+    /**
+     * Delete a position by ID.
+     *
+     * @throws \Saloon\Exceptions\SaloonException
+     */
+    public function delete(int $id): StatusData
+    {
+        $response = $this->connector->send(request: new DeletePosition(id: $id));
+
+        return $response->dtoOrFail();
+    }
+}

--- a/src/Facades/Position.php
+++ b/src/Facades/Position.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingsTelemetry\Traccar\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @see \ThingsTelemetry\Traccar\Endpoints\Position
+ */
+class Position extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     */
+    protected static function getFacadeAccessor(): string
+    {
+        return \ThingsTelemetry\Traccar\Endpoints\Position::class;
+    }
+}

--- a/src/Requests/DeletePosition.php
+++ b/src/Requests/DeletePosition.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingsTelemetry\Traccar\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use ThingsTelemetry\Traccar\Enums\Status;
+use ThingsTelemetry\Traccar\Dto\StatusData;
+
+class DeletePosition extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function __construct(public int $id)
+    {
+    }
+
+    /**
+     * Resolve the API endpoint for deleting a position.
+     */
+    public function resolveEndpoint(): string
+    {
+        return "/positions/{$this->id}";
+    }
+
+    /**
+     * Return an enum status from the response.
+     */
+    public function createDtoFromResponse(Response $response): StatusData
+    {
+        return new StatusData(status: Status::SUCCESS);
+    }
+}

--- a/tests/Feature/PositionTest.php
+++ b/tests/Feature/PositionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use ThingsTelemetry\Traccar\Enums\Status;
+use ThingsTelemetry\Traccar\Dto\StatusData;
+use ThingsTelemetry\Traccar\Facades\Position;
+use ThingsTelemetry\Traccar\Requests\DeletePosition;
+
+it(description: 'can delete a position', closure: function () {
+    MockClient::global(mockData: [
+        DeletePosition::class => MockResponse::make(body: '', status: 204),
+    ]);
+
+    $result = Position::delete(id: 12345);
+
+    expect(value: $result)
+        ->toBeInstanceOf(class: StatusData::class)
+        ->and(value: $result->status)->toEqual(expected: Status::SUCCESS);
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -281,3 +281,12 @@ Route::prefix('/users')->group(function () {
         dump($user->toArray());
     });
 });
+
+Route::prefix('/positions')->group(function () {
+    Route::get('/delete/{id}', function (int $id) {
+        // Example endpoint to test deleting a position
+        $result = \ThingsTelemetry\Traccar\Facades\Position::delete(id: $id);
+
+        dd($result);
+    });
+});


### PR DESCRIPTION
- Introduced `Position::delete` for removing positions by ID.
- Added `DeletePosition` request class to handle API calls.
- Created corresponding test coverage in `PositionTest`.
- Updated documentation with usage examples for deleting positions.
- Registered `Position` facade and API endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Delete Position functionality with Laravel facade support, enabling position deletion via `Position::delete(id)`

* **Documentation**
  * New guide for Delete Position feature with usage examples
  * Grammar improvements to existing endpoint documentation

* **Tests**
  * Added test coverage for Position deletion functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->