### PR TITLE
Added: Find device by ID

### DIFF
--- a/src/Endpoints/Device.php
+++ b/src/Endpoints/Device.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Validator;
 use ThingsTelemetry\Traccar\Dto\DeviceData;
 use ThingsTelemetry\Traccar\Dto\StatusData;
 use ThingsTelemetry\Traccar\Dto\DeviceShareData;
+use ThingsTelemetry\Traccar\Requests\Device\GetDevice;
 use ThingsTelemetry\Traccar\Requests\Device\ShareDevice;
 use ThingsTelemetry\Traccar\Requests\Device\CreateDevice;
 use ThingsTelemetry\Traccar\Requests\Device\DeleteDevice;
@@ -29,6 +30,14 @@ class Device extends Traccar
     public function getAll(): Collection
     {
         $response = $this->connector->send(request: new GetAllDevices());
+
+        return $response->dtoOrFail();
+    }
+
+    /** @throws \Saloon\Exceptions\SaloonException */
+    public function find(int $id): DeviceData
+    {
+        $response = $this->connector->send(request: new GetDevice(id: $id));
 
         return $response->dtoOrFail();
     }

--- a/src/Requests/Device/GetDevice.php
+++ b/src/Requests/Device/GetDevice.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThingsTelemetry\Traccar\Requests\Device;
+
+use JsonException;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use ThingsTelemetry\Traccar\Dto\DeviceData;
+use Saloon\Exceptions\Request\Statuses\NotFoundException;
+
+class GetDevice extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(public int $id)
+    {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return "/devices/{$this->id}";
+    }
+
+    /**
+     * @throws JsonException
+     * @throws \Saloon\Exceptions\Request\Statuses\NotFoundException
+     */
+    public function createDtoFromResponse(Response $response): DeviceData
+    {
+        $json = $response->json();
+
+        if (! is_array($json) || $json === []) {
+            throw new NotFoundException(
+                response: $response,
+                message: 'Traccar device was not found. Check the device ID and try again.'
+            );
+        }
+
+        return DeviceData::fromArray($json);
+    }
+}

--- a/tests/Feature/DeviceTest.php
+++ b/tests/Feature/DeviceTest.php
@@ -16,7 +16,9 @@ use ThingsTelemetry\Traccar\Enums\DeviceStatus;
 use ThingsTelemetry\Traccar\Dto\DeviceShareData;
 use ThingsTelemetry\Traccar\Enums\DeviceCategory;
 use ThingsTelemetry\Traccar\Dto\DeviceAttributesData;
+use ThingsTelemetry\Traccar\Requests\Device\GetDevice;
 use ThingsTelemetry\Traccar\Requests\Device\ShareDevice;
+use Saloon\Exceptions\Request\Statuses\NotFoundException;
 use ThingsTelemetry\Traccar\Requests\Device\CreateDevice;
 use ThingsTelemetry\Traccar\Requests\Device\DeleteDevice;
 use ThingsTelemetry\Traccar\Requests\Device\UpdateDevice;
@@ -81,6 +83,34 @@ it(description: 'can get all devices', closure: function () {
         ->and(value: $first->lastUpdate)->toBeInstanceOf(class: CarbonImmutable::class)
         ->and(value: $first->attributes)->toBeInstanceOf(class: DeviceAttributesData::class)
         ->and(value: $first->attributes->speedLimit)->toBeFloat();
+});
+
+it(description: 'can find a device by id', closure: function () {
+    MockClient::global(mockData: [
+        GetDevice::class => MockResponse::make($this->devices[0]),
+    ]);
+
+    $device = Device::find(id: 6);
+
+    expect(value: $device)
+        ->toBeInstanceOf(class: DeviceData::class)
+        ->and(value: $device->id)->toEqual(expected: 6)
+        ->and(value: $device->name)->toEqual(expected: 'Truck 1')
+        ->and(value: $device->uniqueId)->toEqual(expected: 'ABC123')
+        ->and(value: $device->status)->toEqual(expected: DeviceStatus::ONLINE)
+        ->and(value: $device->category)->toEqual(expected: DeviceCategory::TRUCK)
+        ->and(value: $device->lastUpdate)->toBeInstanceOf(class: CarbonImmutable::class)
+        ->and(value: $device->attributes)->toBeInstanceOf(class: DeviceAttributesData::class)
+        ->and(value: $device->attributes->speedLimit)->toBeFloat();
+});
+
+it(description: 'throws NotFoundException when device is not found', closure: function () {
+    MockClient::global(mockData: [
+        GetDevice::class => MockResponse::make(body: [], status: 200),
+    ]);
+
+    expect(value: fn () => Device::find(id: 999))
+        ->toThrow(exception: NotFoundException::class);
 });
 
 it(description: 'can get devices for a specific user', closure: function () {


### PR DESCRIPTION
This PR adds support for retrieving a device by its ID via the `Device` endpoint.

### Changes

- Added `Device::find(int $id)` method to retrieve a device by ID
- Implemented `Requests\Device\GetDevice` request class
- Returns a `DeviceData` object on success
- Throws `NotFoundException` when the device does not exist
- Added feature tests covering successful retrieval and not-found scenarios

### Benefits

- Enables direct lookup of a single device by ID
- Improves API completeness and developer experience
- Ensures reliability with proper test coverage and error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve a single device by its ID.
  * Improved error handling with notifications when a device cannot be found.

* **Tests**
  * Expanded test coverage for device retrieval functionality and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->